### PR TITLE
ROS 2 minimized base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
             ros/iron/ubuntu/jammy: 'ros/iron/ubuntu/jammy/**'
             ros/jazzy/ubuntu/noble: 'ros/jazzy/ubuntu/noble/**'
             ros/noetic/ubuntu/focal: 'ros/noetic/ubuntu/focal/**'
+            ros/ready/ubuntu: 'ros/ready/ubuntu/**'
             ros/rolling/ubuntu/jammy: 'ros/rolling/ubuntu/jammy/**'
             ros/rolling/ubuntu/noble: 'ros/rolling/ubuntu/noble/**'
             polymath-ros/humble/ubuntu/jammy: 'polymath-ros/humble/ubuntu/jammy/**'

--- a/ros/ready/README.md
+++ b/ros/ready/README.md
@@ -1,0 +1,105 @@
+# ROS 2-Ready Base Images
+
+This directory creates minimized base images that are "ready to receive ROS 2", but don't yet have any packages installed.
+
+These targets are produced:
+
+- ["ready"](#ready)
+- ["builder"](#builder)
+
+## Ready
+
+Tag: `polymathrobotics/ros:${ROS_DISTRO}-ready-ubuntu`
+
+This image is simply fully prepared to install packages for the given ROS 2 distribution without any extra setup.
+
+It has no build tools, and _no_ ROS 2 packages actually installed.
+
+Use case: A basis for a runtime deployment image, with a built application installed in it and ready to run.
+
+## Builder
+
+Tag: `polymathrobotics/ros:${ROS_DISTRO}-builder-ubuntu`
+
+Builds on top of `ready`.
+
+This image has the common ROS build tools installed, but still _no_ ROS packages.
+
+It is ready to receive a colcon source workspace, install its dependencies, then build it.
+
+Use case: CI and development environments.
+
+
+## Usage Patterns
+
+The following `Containerfile` is optimized to get a builder prepared to build your workspace, with exactly its dependencies installed
+
+```containerfile
+ARG TARGET=builder
+ARG ROS_DISTRO=humble
+FROM docker.io/polymathrobotics/ros:${ROS_DISTRO}-${TARGET}-ubuntu AS base
+
+ARG COLCON_SRC=src
+ARG ROSDEP_SKIP_KEYS=""
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+
+####################
+# Rosdep Cache Layer
+# Prevents cache invalidation when sources change but dependency list does not
+####################
+FROM base AS depcache
+
+ARG COLCON_SRC
+ARG ROSDEP_SKIP_KEYS
+
+ENV SKIP_KEYS=${ROSDEP_SKIP_KEYS}
+
+# create file install_rosdeps.sh that won't change and bust cache if no dependencies change
+RUN --mount=type=bind,source=${COLCON_SRC},target=/tmp/src \
+    rosdep update \
+ && gather-rosdeps /tmp/install_rosdeps.sh /tmp/src
+
+#################
+# Workspace Layer: Installs dependencies to create a workspace ready to build your application
+#################
+FROM base AS workspace
+
+COPY --from=depcache /tmp/install_rosdeps.sh /tmp/install_rosdeps.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+ && cat /tmp/install_rosdeps.sh \
+ && /tmp/install_rosdeps.sh \
+ && rm -rf /var/lib/apt/lists/*
+```
+
+
+Example usage:
+
+```bash
+$ cd my_application_workspace
+$ ls -1F
+Containerfile
+src/
+
+# Create the prepared workspace builder with all dependencies installed
+$ docker build . \
+  -f Containerfile \
+  --build-arg TARGET=builder \
+  --build-arg ROS_DISTRO=humble \
+  --build-arg COLCON_SRC=src \
+  -t my_application:humble-builder
+
+# Run a noninteractive build
+$ docker run \
+  -v $(pwd):/ros_workspace \
+  -w /ros_workspace \
+  my_application:humble-builder \
+  /bin/bash -c "source /opt/ros/humble/setup.bash && colcon build"
+
+
+# Or, you can run an interactive session within the container for development
+$ docker run -v $(pwd):/ros_workspace -w /ros_workspace -it my_application:humble-builder
+```

--- a/ros/ready/ubuntu/Containerfile
+++ b/ros/ready/ubuntu/Containerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG UBUNTU_DISTRO=rolling
-ARG UBUNTU_DISTRO_VERSION=0.12.0-1
-ARG BASE_IMAGE=docker.io/ubuntu:${UBUNTU_DISTRO}-${UBUNTU_DISTRO_VERSION}
+ARG BASE_IMAGE=ubuntu:noble-20241015
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} AS base
 
@@ -19,59 +17,62 @@ RUN <<EOF
     -o /usr/share/keyrings/ros2-latest-archive-keyring.gpg
 EOF
 
-FROM base AS ready
 
-ARG UBUNTU_DISTRO
-ARG ROS_PACKAGES_URI
-ARG ROSDISTRO_PKGS_SYNC_DATE
+FROM base AS ready
 
 COPY --from=download /usr/share/keyrings/ros2-latest-archive-keyring.gpg /usr/share/keyrings/ros2-latest-archive-keyring.gpg
 
 # setup timezone
-RUN echo 'Etc/UTC' > /etc/timezone && \
-    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends tzdata && \
-    rm -rf /var/lib/apt/lists/*
+RUN echo 'Etc/UTC' > /etc/timezone \
+ && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+ && apt-get update \
+ && apt-get install -q -y --no-install-recommends tzdata \
+ && rm -rf /var/lib/apt/lists/*
 
 # install packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    dirmngr \
-    gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -q -y --no-install-recommends \
+      dirmngr \
+      gnupg2 \
+ && rm -rf /var/lib/apt/lists/*
 
 # setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] ${ROS_PACKAGES_URI} ${UBUNTU_DISTRO} main" > /etc/apt/sources.list.d/ros2-latest.list
+ARG ROS_PACKAGES_URI
+RUN . /etc/os-release; \
+    echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] ${ROS_PACKAGES_URI} ${UBUNTU_CODENAME} main" \
+    > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+ARG ROSDISTRO_PKGS_SYNC_DATE
 ENV ROSDISTRO_PKGS_SYNC_DATE=$ROSDISTRO_PKGS_SYNC_DATE
+
+ARG ROS_DISTRO
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 FROM ready AS builder
 
-ARG RAW_GITHUBUSERCONTENT_BASE_URL
-
 # install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    ros-dev-tools \
-    python3-pip \
-    ccache \
-    && rm -rf /var/lib/apt/lists/*
-
-# setup colcon mixin and metadata
-ENV COLCON_HOME=/etc/colcon
-RUN colcon mixin add default \
-      "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-mixin-repository/master/index.yaml" && \
-    colcon mixin update && \
-    colcon metadata add default \
-      "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-metadata-repository/master/index.yaml" && \
-    colcon metadata update
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+      ros-dev-tools \
+      python3-pip \
+      ccache \
+ && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep
 # NOTE: this is the first step that actually differentiates on ROS distribution
-ARG ROS_DISTRO
-ENV ROS_DISTRO=${ROS_DISTRO}
 RUN rosdep init && rosdep update --rosdistro "${ROS_DISTRO}"
 COPY gather-rosdeps.sh /usr/local/bin/gather-rosdeps
+
+ENV CCACHE_DIR=/root/.ccache
+
+# setup colcon mixin and metadata
+ARG RAW_GITHUBUSERCONTENT_BASE_URL
+ENV COLCON_HOME=/etc/colcon
+RUN colcon mixin add default "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-mixin-repository/master/index.yaml" \
+ && colcon mixin update \
+ && colcon metadata add default "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-metadata-repository/master/index.yaml" \
+ && colcon metadata update

--- a/ros/ready/ubuntu/Containerfile
+++ b/ros/ready/ubuntu/Containerfile
@@ -57,6 +57,7 @@ ARG RAW_GITHUBUSERCONTENT_BASE_URL
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ros-dev-tools \
     python3-pip \
+    ccache \
     && rm -rf /var/lib/apt/lists/*
 
 # setup colcon mixin and metadata

--- a/ros/ready/ubuntu/Containerfile
+++ b/ros/ready/ubuntu/Containerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+ARG UBUNTU_DISTRO=rolling
+ARG UBUNTU_DISTRO_VERSION=0.12.0-1
+ARG BASE_IMAGE=docker.io/ubuntu:${UBUNTU_DISTRO}-${UBUNTU_DISTRO_VERSION}
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE} AS base
+
+FROM base AS download
+
+ARG RAW_GITHUBUSERCONTENT_BASE_URL
+
+# download gpg key
+RUN <<EOF
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl
+  curl -sSL "${RAW_GITHUBUSERCONTENT_BASE_URL}/ros/rosdistro/master/ros.key" \
+    -o /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+EOF
+
+FROM base AS ready
+
+ARG UBUNTU_DISTRO
+ARG ROS_PACKAGES_URI
+ARG ROSDISTRO_PKGS_SYNC_DATE
+
+COPY --from=download /usr/share/keyrings/ros2-latest-archive-keyring.gpg /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] ${ROS_PACKAGES_URI} ${UBUNTU_DISTRO} main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# setup environment
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ENV ROSDISTRO_PKGS_SYNC_DATE=$ROSDISTRO_PKGS_SYNC_DATE
+
+FROM ready AS builder
+
+ARG RAW_GITHUBUSERCONTENT_BASE_URL
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ros-dev-tools \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup colcon mixin and metadata
+ENV COLCON_HOME=/etc/colcon
+RUN colcon mixin add default \
+      "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-mixin-repository/master/index.yaml" && \
+    colcon mixin update && \
+    colcon metadata add default \
+      "${RAW_GITHUBUSERCONTENT_BASE_URL}/colcon/colcon-metadata-repository/master/index.yaml" && \
+    colcon metadata update
+
+# bootstrap rosdep
+# NOTE: this is the first step that actually differentiates on ROS distribution
+ARG ROS_DISTRO
+ENV ROS_DISTRO=${ROS_DISTRO}
+RUN rosdep init && rosdep update --rosdistro "${ROS_DISTRO}"
+COPY gather-rosdeps.sh /usr/local/bin/gather-rosdeps

--- a/ros/ready/ubuntu/docker-bake.hcl
+++ b/ros/ready/ubuntu/docker-bake.hcl
@@ -1,0 +1,70 @@
+variable "TAG_PREFIX" {
+  default =  "docker.io/polymathrobotics/ros"
+}
+
+# There's no darwin-based Docker, so if we're running on macOS, change the platform to linux
+variable "LOCAL_PLATFORM" {
+  default = regex_replace("${BAKE_LOCAL_PLATFORM}", "^(darwin)", "linux")
+}
+
+variable "DISTRO" {
+  default = [
+    {ros = "humble",  ros_version = "0.10.0-1", ubuntu = "jammy", ubuntu_version = "20240911.1"},
+    {ros = "jazzy",   ros_version = "0.11.0-1", ubuntu = "noble", ubuntu_version = "20241015"},
+    {ros = "rolling", ros_version = "0.12.0-1", ubuntu = "noble", ubuntu_version = "20241015"},
+  ]
+}
+
+variable "VARIANT" {
+  default = ["ready", "builder"]
+}
+
+target "_common" {
+  args = {
+    ROS_PACKAGES_URI = "http://packages.ros.org/ros2/ubuntu"
+    RAW_GITHUBUSERCONTENT_BASE_URL = "https://raw.githubusercontent.com"
+    ROSDISTRO_PKGS_SYNC_DATE = "${formatdate("YYYY-MM-DD", timestamp())}"
+  }
+  dockerfile = "Containerfile"
+  labels = {
+    "org.opencontainers.image.source" = "https://github.com/polymathrobotics/oci/blob/main/ros/ubuntu/Containerfile"
+    "org.opencontainers.image.licenses" = "Apache-2.0"
+    "org.opencontainers.image.description" = "The Robot Operating System (ROS) is an open source project for building robot applications."
+    "org.opencontainers.image.title" = "${TAG_PREFIX}"
+    "org.opencontainers.image.created" = "${timestamp()}"
+    "dev.polymathrobotics.image.readme-filepath" = "ros/README.md"
+  }
+}
+
+target "local" {
+  inherits = ["_common"]
+  matrix = {
+    variant = VARIANT
+    distro = DISTRO
+  }
+  target = variant
+  name = "local-${distro.ros}-${variant}"
+  tags = [
+    "${TAG_PREFIX}:${distro.ros}-${variant}-ubuntu"
+  ]
+  args = {
+    ROS_DISTRO = distro.ros
+    ROS_DISTRO_VERSION = distro.ros_version
+    UBUNTU_DISTRO = distro.ubuntu
+    UBUNTU_DISTRO_VERSION = distro.ubuntu_version
+  }
+  platforms = ["${LOCAL_PLATFORM}"]
+}
+
+# target "default" {
+#   inherits = ["_common"]
+#   name = "default-${ros_package}"
+#   target = ros_package
+#   matrix = {
+#     ros_package = ROS_PACKAGE
+#   }
+#   tags = [
+#     "${TAG_PREFIX}:jazzy-${ros_package}-noble"
+#   ]
+#   platforms = ["linux/amd64", "linux/arm64/v8"]
+# }

--- a/ros/ready/ubuntu/docker-bake.hcl
+++ b/ros/ready/ubuntu/docker-bake.hcl
@@ -9,9 +9,9 @@ variable "LOCAL_PLATFORM" {
 
 variable "DISTRO" {
   default = [
-    {ros = "humble",  ros_version = "0.10.0-1", ubuntu = "jammy", ubuntu_version = "20240911.1"},
-    {ros = "jazzy",   ros_version = "0.11.0-1", ubuntu = "noble", ubuntu_version = "20241015"},
-    {ros = "rolling", ros_version = "0.12.0-1", ubuntu = "noble", ubuntu_version = "20241015"},
+    {ros = "humble",  base_image = "ubuntu:jammy-20240911.1"},
+    {ros = "jazzy",   base_image = "ubuntu:noble-20241015"},
+    {ros = "rolling", base_image = "ubuntu:noble-20241015"},
   ]
 }
 
@@ -49,9 +49,7 @@ target "local" {
   ]
   args = {
     ROS_DISTRO = distro.ros
-    ROS_DISTRO_VERSION = distro.ros_version
-    UBUNTU_DISTRO = distro.ubuntu
-    UBUNTU_DISTRO_VERSION = distro.ubuntu_version
+    BASE_IMAGE = distro.base_image
   }
   platforms = ["${LOCAL_PLATFORM}"]
 }
@@ -69,9 +67,7 @@ target "default" {
   ]
   args = {
     ROS_DISTRO = distro.ros
-    ROS_DISTRO_VERSION = distro.ros_version
-    UBUNTU_DISTRO = distro.ubuntu
-    UBUNTU_DISTRO_VERSION = distro.ubuntu_version
+    BASE_IMAGE = distro.base_image
   }
   platforms = ["linux/amd64", "linux/arm64/v8"]
 }

--- a/ros/ready/ubuntu/docker-bake.hcl
+++ b/ros/ready/ubuntu/docker-bake.hcl
@@ -56,15 +56,22 @@ target "local" {
   platforms = ["${LOCAL_PLATFORM}"]
 }
 
-# target "default" {
-#   inherits = ["_common"]
-#   name = "default-${ros_package}"
-#   target = ros_package
-#   matrix = {
-#     ros_package = ROS_PACKAGE
-#   }
-#   tags = [
-#     "${TAG_PREFIX}:jazzy-${ros_package}-noble"
-#   ]
-#   platforms = ["linux/amd64", "linux/arm64/v8"]
-# }
+target "default" {
+  inherits = ["_common"]
+  matrix = {
+    variant = VARIANT
+    distro = DISTRO
+  }
+  target = variant
+  name = "default-${distro.ros}-${variant}"
+  tags = [
+    "${TAG_PREFIX}:${distro.ros}-${variant}-ubuntu"
+  ]
+  args = {
+    ROS_DISTRO = distro.ros
+    ROS_DISTRO_VERSION = distro.ros_version
+    UBUNTU_DISTRO = distro.ubuntu
+    UBUNTU_DISTRO_VERSION = distro.ubuntu_version
+  }
+  platforms = ["linux/amd64", "linux/arm64/v8"]
+}

--- a/ros/ready/ubuntu/gather-rosdeps.sh
+++ b/ros/ready/ubuntu/gather-rosdeps.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: gather_rosdeps.sh <dest> <path1> <path2> ...
+# Writes a script to file <dest> with commands to install all rosdep dependencies for packages in <path1> <path2> ...
+
+DEST=$1
+shift
+
+initial=$(
+  PIP_BREAK_SYSTEM_PACKAGES=1 \
+  rosdep install \
+  --from-paths "$@" \
+  --ignore-src \
+  --skip-keys "${SKIP_KEYS:-""}" \
+  --rosdistro "$ROS_DISTRO" \
+  --default-yes \
+  --simulate)
+
+# Combine all apt-get install lines into a single command
+# This makes there be only a single "reading package lists", which can take nontrivial time
+# and so allows for a significant speedup when there are many "apt-get install" commands,
+# especially when an earlier package installs a package that is later installed manually,
+# which is a noop that takes multiple seconds per package
+
+# Finds lines with "apt-get install", extracts the last word (package name), then sorts
+apt_deps=$(echo "$initial" | grep "apt-get install" | sed 's/'\''\(apt-get install -y\)\(.*\)'\'' .*/\1\2/g' | awk '{print $NF}' | sort | tr '\n' ' ') || echo ''
+if [ -n "${apt_deps}" ]; then
+  apt_statement="apt-get install -y --no-install-recommends -q ${apt_deps}"
+else
+  apt_statement=""
+fi
+
+# Combine all pip install lines into a single command
+pip_deps=$(echo "$initial" | grep "pip3 install" | awk '{print $NF}' | sort | tr '\n' ' ') || echo ''
+if [ -n "${pip_deps}" ]; then
+  pip_statement="PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install ${pip_deps}"
+else
+  pip_statement=""
+fi
+
+cat << EOF > "$DEST"
+#!/bin/bash
+set -euxo pipefail
+${apt_statement}
+${pip_statement}
+EOF
+chmod +x "$DEST"
+
+echo "Success!"

--- a/ros/ready/ubuntu/ros_entrypoint.sh
+++ b/ros/ready/ubuntu/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"

--- a/ros/ready/ubuntu/ros_entrypoint.sh
+++ b/ros/ready/ubuntu/ros_entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# setup ros2 environment
-source "/opt/ros/$ROS_DISTRO/setup.bash" --
-exec "$@"

--- a/ros/ready/ubuntu/test/controls/ros_ready.rb
+++ b/ros/ready/ubuntu/test/controls/ros_ready.rb
@@ -1,0 +1,165 @@
+
+describe os_env('LANG') do
+  its('content') { should eq 'C.UTF-8' }
+end
+
+describe os_env('ROSDISTRO_PKGS_SYNC_DATE') do
+  its('content') { should match /^\d{4}-\d{2}-\d{2}$/ }
+end
+
+describe file('/usr/share/keyrings/ros2-latest-archive-keyring.gpg') do
+  it { should exist }
+end
+
+# docker.io/polymathrobotics/ros:humble-ready-ubuntu
+control 'humble-ready' do
+  only_if('humble-ready') do
+    input('test_container_image').include?('ros:humble-ready-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '22.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'humble' }
+  end
+  describe file('/etc/apt/sources.list.d/ros2-latest.list') do
+      it { should exist }
+      its('content') { should match %r{jammy main} }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should_not exist }
+    end
+  end
+end
+
+# docker.io/polymathrobotics/ros:humble-builder-ubuntu
+control 'humble-builder' do
+  only_if('humble-builder') do
+    input('test_container_image').include?('ros:humble-builder-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '22.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'humble' }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should exist }
+    end
+  end
+  describe file('/usr/local/bin/gather-rosdeps') do
+    it { should exist }
+  end
+end
+
+# docker.io/polymathrobotics/ros:jazzy-ready-ubuntu
+control 'jazzy-ready' do
+  only_if('jazzy-ready') do
+    input('test_container_image').include?('ros:jazzy-ready-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '24.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'jazzy' }
+  end
+  describe file('/etc/apt/sources.list.d/ros2-latest.list') do
+      it { should exist }
+      its('content') { should match %r{noble main} }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should_not exist }
+    end
+  end
+end
+
+# docker.io/polymathrobotics/ros:jazzy-builder-ubuntu
+control 'jazzy-builder' do
+  only_if('jazzy-builder') do
+    input('test_container_image').include?('ros:jazzy-builder-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '24.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'jazzy' }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should exist }
+    end
+  end
+  describe file('/usr/local/bin/gather-rosdeps') do
+    it { should exist }
+  end
+end
+
+# docker.io/polymathrobotics/ros:rolling-ready-ubuntu
+control 'rolling-ready' do
+  only_if('rolling-ready') do
+    input('test_container_image').include?('ros:rolling-ready-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '24.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'rolling' }
+  end
+  describe file('/etc/apt/sources.list.d/ros2-latest.list') do
+      it { should exist }
+      its('content') { should match %r{noble main} }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should_not exist }
+    end
+  end
+end
+
+# docker.io/polymathrobotics/ros:rolling-builder-ubuntu
+control 'rolling-builder' do
+  only_if('rolling-builder') do
+    input('test_container_image').include?('ros:rolling-builder-ubuntu')
+  end
+  describe os do
+    its('name') { should eq 'ubuntu' }
+    its('release') { should eq '24.04' }
+  end
+  describe os_env('ROS_DISTRO') do
+    its('content') { should eq 'rolling' }
+  end
+  %w(
+    colcon
+    rosdep
+  ).each do |cmd|
+    describe command(cmd) do
+      it { should exist }
+    end
+  end
+  describe file('/usr/local/bin/gather-rosdeps') do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
Create new ROS 2 base images which are optimized for use in CI, development, and deployment 

Creates these variants for all live ROS 2 distributions:
  - `ros/${ROS_DISTRO}-ready-ubuntu`: this image is fully set up to install ROS 2 packages, but has not yet installed anything. Intended as "ready to install" a given ROS 2 application runtime environment. It does not contain build tooling.
  - `polymathrobotics/ros/${ROS_DISTRO}-builder-ubuntu`: Extends `ready`, contains the base tooling common for building ROS 2 application workspaces. This image is intended to have a workspace mounted, install its dependencies efficiently as possible, and be capable of then building the code . Intended for CI and development environment use.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209632010072982