### PR TITLE
gstreamer-publisher image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             github-cli: 'github-cli/**'
             glab: 'glab/**'
             go2chef: 'go2chef/**'
+            gstreamer-publisher: 'gstreamer-publisher/**'
             golang/1.23/noble: 'golang/1.23/noble/**'
             golang/1.24/noble: 'golang/1.24/noble/**'
             grafana/grafana-oss: 'grafana/grafana-oss/**'

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The images are pubished to https://hub.docker.com/u/polymathrobotics
 | [gh](https://hub.docker.com/r/polymathrobotics/gh) | The GitHub CLI tool | [github-cli](https://github.com/polymathrobotics/oci/tree/main/github-cli) |
 | [glab](https://hub.docker.com/r/polymathrobotics/glab) | The GitLab CLI tool | [glab](https://github.com/polymathrobotics/oci/tree/main/glab) |
 | [go2chef](https://hub.docker.com/r/polymathrobotics/go2chef) | A Golang tool to bootstrap a system from zero so that it's able to run Chef | [go2chef](https://github.com/polymathrobotics/oci/tree/main/go2chef) |
+| [gstreamer-publisher](https://hub.docker.com/r/polymathrobotics/gstreamer-publisher) | Command-line app that publishes any GStreamer pipeline to LiveKit | [gstreamer-publisher](https://github.com/polymathrobotics/oci/tree/main/gstreamer-publisher) |
 | [golang](https://hub.docker.com/r/polymathrobotics/golang) | Go (golang) is a general purpose, higher-level, imperative programming language. | [golang](https://github.com/polymathrobotics/oci/tree/main/golang) |
 | [grafana-oss](https://hub.docker.com/r/polymathrobotics/grafana-oss) | Grafana - the open observability platform | [grafana/grafana-oss](https://github.com/polymathrobotics/oci/tree/main/grafana/grafana-oss) |
 | [hadolint](https://hub.docker.com/r/polymathrobotics/hadolint) | Containerfile/Dockerfile linter | [hadolint](https://github.com/polymathrobotics/oci/tree/main/hadolint) |

--- a/gstreamer-publisher/.dockerignore
+++ b/gstreamer-publisher/.dockerignore
@@ -1,0 +1,2 @@
+README.md
+test/

--- a/gstreamer-publisher/Containerfile
+++ b/gstreamer-publisher/Containerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+# Arguments used in FROM need to be defined before the first build stage
+ARG BUILD_IMAGE=docker.io/polymathrobotics/ros:humble-builder-ubuntu
+ARG GOLANG_IMAGE=docker.io/polymathrobotics/golang:1.24-noble
+ARG RUNTIME_BASE_IMAGE=docker.io/ubuntu:jammy-20260217
+
+FROM ${GOLANG_IMAGE} AS golang-toolchain
+
+FROM ${BUILD_IMAGE} AS build
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG GSTREAMER_PUBLISHER_REF
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GOTOOLCHAIN=local
+ENV GOPATH=/go
+ENV PATH=/go/bin:/usr/local/go/bin:${PATH}
+
+WORKDIR /tmp
+
+COPY --from=golang-toolchain /usr/local/go /usr/local/go
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+      libgstreamer-plugins-base1.0-dev \
+      libgstreamer1.0-dev \
+      pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git init /tmp/gstreamer-publisher \
+ && git -C /tmp/gstreamer-publisher remote add origin https://github.com/livekit/gstreamer-publisher \
+ && git -C /tmp/gstreamer-publisher fetch --depth 1 origin "${GSTREAMER_PUBLISHER_REF}" \
+ && git -C /tmp/gstreamer-publisher checkout FETCH_HEAD \
+ && GOFLAGS='-p=1' go build -C /tmp/gstreamer-publisher -o /usr/local/bin/gstreamer-publisher .
+
+FROM ${RUNTIME_BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-plugins-good \
+      gstreamer1.0-tools \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build --chmod=755 /usr/local/bin/gstreamer-publisher /usr/local/bin/gstreamer-publisher
+
+ENTRYPOINT ["/usr/local/bin/gstreamer-publisher"]
+CMD ["--help"]

--- a/gstreamer-publisher/Containerfile
+++ b/gstreamer-publisher/Containerfile
@@ -46,6 +46,7 @@ RUN apt-get update \
       ca-certificates \
       gstreamer1.0-plugins-base \
       gstreamer1.0-plugins-good \
+      gstreamer1.0-plugins-ugly \
       gstreamer1.0-tools \
  && rm -rf /var/lib/apt/lists/*
 

--- a/gstreamer-publisher/Containerfile
+++ b/gstreamer-publisher/Containerfile
@@ -4,8 +4,10 @@ ARG BUILD_IMAGE=docker.io/polymathrobotics/ros:humble-builder-ubuntu
 ARG GOLANG_IMAGE=docker.io/polymathrobotics/golang:1.24-noble
 ARG RUNTIME_BASE_IMAGE=docker.io/ubuntu:jammy-20260217
 
+# hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} AS golang-toolchain
 
+# hadolint ignore=DL3006
 FROM ${BUILD_IMAGE} AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -35,6 +37,7 @@ RUN git init /tmp/gstreamer-publisher \
  && git -C /tmp/gstreamer-publisher checkout FETCH_HEAD \
  && GOFLAGS='-p=1' go build -C /tmp/gstreamer-publisher -o /usr/local/bin/gstreamer-publisher .
 
+# hadolint ignore=DL3006
 FROM ${RUNTIME_BASE_IMAGE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -44,10 +47,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
+      gstreamer1.0-plugins-bad \
       gstreamer1.0-plugins-base \
       gstreamer1.0-plugins-good \
       gstreamer1.0-plugins-ugly \
       gstreamer1.0-tools \
+      gstreamer1.0-x \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chmod=755 /usr/local/bin/gstreamer-publisher /usr/local/bin/gstreamer-publisher

--- a/gstreamer-publisher/README.md
+++ b/gstreamer-publisher/README.md
@@ -1,0 +1,17 @@
+# gstreamer-publisher
+
+`gstreamer-publisher` publishes video and audio from a GStreamer pipeline to
+LiveKit.
+
+This image builds pinned revisions from
+https://github.com/livekit/gstreamer-publisher
+
+Image source: https://github.com/polymathrobotics/oci/tree/main/gstreamer-publisher
+
+Use the `jammy` tag for ROS Humble-compatible builds and `noble` for newer ROS
+distributions.
+
+```bash
+docker container run --rm \
+  docker.io/polymathrobotics/gstreamer-publisher:jammy --help
+```

--- a/gstreamer-publisher/docker-bake.hcl
+++ b/gstreamer-publisher/docker-bake.hcl
@@ -70,5 +70,5 @@ target "default" {
     GSTREAMER_PUBLISHER_REF = distro.gstreamer_publisher_ref
     RUNTIME_BASE_IMAGE = distro.runtime_base_image
   }
-  platforms = ["linux/amd64"]
+  platforms = ["linux/amd64", "linux/arm64/v8"]
 }

--- a/gstreamer-publisher/docker-bake.hcl
+++ b/gstreamer-publisher/docker-bake.hcl
@@ -1,0 +1,74 @@
+variable "TAG_PREFIX" {
+  default = "docker.io/polymathrobotics/gstreamer-publisher"
+}
+
+variable "LOCAL_PLATFORM" {
+  default = regex_replace("${BAKE_LOCAL_PLATFORM}", "^(darwin)", "linux")
+}
+
+variable "DISTRO" {
+  default = [
+    {
+      name = "jammy"
+      build_image = "docker.io/polymathrobotics/ros:humble-builder-ubuntu"
+      runtime_base_image = "docker.io/ubuntu:jammy-20260217"
+      gstreamer_publisher_ref = "8825fee6f40ff51f2cf9347892f6fbc08eeb1f2e"
+    },
+    {
+      name = "noble"
+      build_image = "docker.io/polymathrobotics/ros:rolling-builder-ubuntu"
+      runtime_base_image = "docker.io/ubuntu:noble-20260217"
+      gstreamer_publisher_ref = "407891dbdca2ad3113270fbeb350ab9f47615917"
+    },
+  ]
+}
+
+target "_common" {
+  dockerfile = "Containerfile"
+  labels = {
+    "org.opencontainers.image.source" = "https://github.com/polymathrobotics/oci/tree/main/gstreamer-publisher"
+    "org.opencontainers.image.licenses" = "Apache-2.0"
+    "org.opencontainers.image.description" = "Command-line app that publishes any GStreamer pipeline to LiveKit."
+    "org.opencontainers.image.title" = "${TAG_PREFIX}"
+    "org.opencontainers.image.created" = "${timestamp()}"
+    "dev.polymathrobotics.image.readme-filepath" = "gstreamer-publisher/README.md"
+  }
+}
+
+target "local" {
+  inherits = ["_common"]
+  matrix = {
+    distro = DISTRO
+  }
+  name = "local-${distro.name}"
+  tags = [
+    "${TAG_PREFIX}:${distro.name}",
+    "${TAG_PREFIX}:${distro.name}-${distro.gstreamer_publisher_ref}",
+  ]
+  args = {
+    BUILD_IMAGE = distro.build_image
+    GOLANG_IMAGE = "docker.io/polymathrobotics/golang:1.24-noble"
+    GSTREAMER_PUBLISHER_REF = distro.gstreamer_publisher_ref
+    RUNTIME_BASE_IMAGE = distro.runtime_base_image
+  }
+  platforms = ["${LOCAL_PLATFORM}"]
+}
+
+target "default" {
+  inherits = ["_common"]
+  matrix = {
+    distro = DISTRO
+  }
+  name = "default-${distro.name}"
+  tags = [
+    "${TAG_PREFIX}:${distro.name}",
+    "${TAG_PREFIX}:${distro.name}-${distro.gstreamer_publisher_ref}",
+  ]
+  args = {
+    BUILD_IMAGE = distro.build_image
+    GOLANG_IMAGE = "docker.io/polymathrobotics/golang:1.24-noble"
+    GSTREAMER_PUBLISHER_REF = distro.gstreamer_publisher_ref
+    RUNTIME_BASE_IMAGE = distro.runtime_base_image
+  }
+  platforms = ["linux/amd64"]
+}

--- a/gstreamer-publisher/test/controls/gstreamer_publisher.rb
+++ b/gstreamer-publisher/test/controls/gstreamer_publisher.rb
@@ -3,6 +3,15 @@ describe command('gstreamer-publisher --help') do
   its('stdout') { should match(/Publish video\/audio from a GStreamer pipeline to LiveKit/) }
 end
 
-describe command('gst-inspect-1.0 x264enc') do
-  its('exit_status') { should eq 0 }
+%w[
+  clockoverlay
+  decodebin3
+  h264parse
+  opusenc
+  vp9enc
+  x264enc
+].each do |plugin|
+  describe command("gst-inspect-1.0 #{plugin}") do
+    its('exit_status') { should eq 0 }
+  end
 end

--- a/gstreamer-publisher/test/controls/gstreamer_publisher.rb
+++ b/gstreamer-publisher/test/controls/gstreamer_publisher.rb
@@ -2,3 +2,7 @@ describe command('gstreamer-publisher --help') do
   its('exit_status') { should eq 0 }
   its('stdout') { should match(/Publish video\/audio from a GStreamer pipeline to LiveKit/) }
 end
+
+describe command('gst-inspect-1.0 x264enc') do
+  its('exit_status') { should eq 0 }
+end

--- a/gstreamer-publisher/test/controls/gstreamer_publisher.rb
+++ b/gstreamer-publisher/test/controls/gstreamer_publisher.rb
@@ -1,0 +1,4 @@
+describe command('gstreamer-publisher --help') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/Publish video\/audio from a GStreamer pipeline to LiveKit/) }
+end


### PR DESCRIPTION
Adds a [gstreamer-publisher](https://github.com/livekit/gstreamer-publisher) image for publishing GStreamer pipelines to LiveKit, with pinned upstream revisions for both the `jammy` and `noble` variants.

This includes:
- build and publish definitions for `jammy` and `noble`, including `linux/amd64` and `linux/arm64/v8` outputs and the runtime GStreamer plugins needed by the binary
- image-level docs and tests that verify `gstreamer-publisher --help` and required plugins including `x264enc`
